### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The fediverse is made up of a bunch of protocols. Below are the most used ones.
 - [PubSubHubbub](https://github.com/pubsubhubbub/PubSubHubbub) - PubSubHubbub is an open protocol for distributed publish/subscribe communication on the Internet. It generalizes the concept of webhooks and allows data producers and data consumers to work in a decoupled way.
 - [Pubcast](https://github.com/pubcast/pubcast) - An experimental ActivityPub based podcasting platform
 - [Pubgate](https://github.com/autogestion/pubgate) - Lightweight (Gotta Go Fast) ActivityPub federator
+- [Mathematical Mesh](https://github.com/hallambaker/Mathematical-Mesh) Open infrastructure for managing public and private keys. Provides mechanisms for sharing public and private keys for use with any cryptographic application across devices. Provides management of contacts, bookmarks and other personal data. Supports two factor authentication mechanism, end-to-end secure messages and sharing encrypted data with dynamic groups of users.
 
 ## Sites
 


### PR DESCRIPTION
Proposing to add the Mathematical Mesh to the protocols section.

The Mesh is basically a Swiss army knife of cryptography. It supports everything OpenPGP, S/MIME and PKIX do. Signal type capabilities in a non-walled garden environment are being added.

The Mesh potentially allows an entirely end-to-end encrypted social media/collaboration experience. That is with all the documents on the host being encrypted such that the hosting site has no access to the plaintext or the decryption keys.